### PR TITLE
Resolve date specific test issues

### DIFF
--- a/app/services/mapbox_service.rb
+++ b/app/services/mapbox_service.rb
@@ -7,14 +7,17 @@ class MapboxService
   end
 
   def get_geo(coord_list)
-    conn = Faraday.new('https://api.mapbox.com/directions/v5/mapbox/driving/')
+    conn = Faraday.new('https://api.mapbox.com/optimized-trips/v1/mapbox/driving/')
     response = conn.get(coord_prep(coord_list)) do |r|
       r.params['access_token'] = api_key
       r.params['geometries'] = 'geojson'
       r.params['overview'] = 'full'
+      r.params['source'] = 'first'
+      r.params['destination'] = 'last'
+      r.params['roundtrip'] = 'false'
     end
     geo_json = JSON.parse(response.body, symbolize_names: true)
-    geo_json[:routes].first[:geometry][:coordinates]
+    geo_json[:trips].first[:geometry][:coordinates]
   end
 
   private

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,10 +34,12 @@ user_5 = User.create!(full_name: "Jerk", email: "jerk@example.com", about: "I'm 
 
 address_11 = Address.create!(owner: user_1, line_1: "Civic Center Station", line_2: "Along Colfax westbound", city: "Denver", state: "CO", zip: "80202", default: true, longitude: '-104.9870', latitude: '39.7402')
 address_12 = Address.create!(owner: user_1, line_1: "Union Station", line_2: "Wynkoop and 17th", city: "Denver", state: "CO", zip: "80202", default: false, longitude: '-104.9997', latitude: '39.7528')
-address_21 = Address.create!(owner: user_2, line_1: "Central Park S and 7th", city: "New York", state: "NY", zip: "10019", default: true, longitude: '-73.9790', latitude: '40.7669')
+address_21 = Address.create!(owner: user_2, line_1: "Central Park S and 7th", city: "New York", state: "NY", zip: "10019", default: false, longitude: '-73.9790', latitude: '40.7669')
 address_22 = Address.create!(owner: user_2, line_1: "World Trade Center Memorial", city: "New York", state: "NY", zip: "10007", default: false, longitude: '-74.0122', latitude: '40.7115')
-address_31 = Address.create!(owner: user_3, line_1: "Dodgers Stadium parking lot", city: "Los Angeles", state: "CA", zip: "90099", default: true, longitude: '-118.2411', latitude: '34.0682')
+address_23 = Address.create!(owner: user_2, line_1: "Civic Center Station", line_2: "Along Colfax westbound", city: "Denver", state: "CO", zip: "80202", default: true, longitude: '-104.9870', latitude: '39.7402')
+address_31 = Address.create!(owner: user_3, line_1: "Dodgers Stadium parking lot", city: "Los Angeles", state: "CA", zip: "90099", default: false, longitude: '-118.2411', latitude: '34.0682')
 address_32 = Address.create!(owner: user_3, line_1: "Union Station loading area", line_2: "West side", city: "Los Angeles", state: "CA", zip: "90099", default: false, longitude: '-118.2368', latitude: '34.0561')
+address_33 = Address.create!(owner: user_3, line_1: "Civic Center Station", line_2: "Along Colfax westbound", city: "Denver", state: "CO", zip: "80202", default: true, longitude: '-104.9870', latitude: '39.7402')
 address_41 = Address.create!(owner: user_4, line_1: "Civic Center Station", line_2: "Along Colfax westbound", city: "Denver", state: "CO", zip: "80202", default: false, longitude: '-104.9870', latitude: '39.7402')
 address_42 = Address.create!(owner: user_4, line_1: "Union Station", line_2: "Wynkoop and 17th", city: "Denver", state: "CO", zip: "80202", default: true, longitude: '-104.9997', latitude: '39.7528')
 
@@ -85,7 +87,7 @@ demo_users = names.map do |name|
   google_id: nil,
   role: :default,
   active: true)
-  Address.create!(owner: user, line_1: "At #{name}'s favorite place", city: "Denver", state: "CO", zip: "80802", default: true, longitude: rng.rand((-105.5000)..(-104.5000)).to_s, latitude: rng.rand(39.7000..39.8000).to_s)
+  Address.create!(owner: user, line_1: "At #{name}'s favorite place", city: "Denver", state: "CO", zip: "80802", default: true, longitude: rng.rand((-105.1400)..(-104.7300)).to_s, latitude: rng.rand(39.5800..39.7900).to_s)
   user
 end
 

--- a/spec/features/admins/projects/edit_spec.rb
+++ b/spec/features/admins/projects/edit_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
+require 'date'
 
 describe 'As an admin' do
   before :each do
+    future_date = (Date.today >> 1).strftime('%Y-%m-%d')
     @admin = User.new(full_name: "Vincent",
                      email: "vincent@example.com",
                      about: "TBD",
@@ -10,7 +12,7 @@ describe 'As an admin' do
                      google_id: nil,
                      role: 2,
                      active: true)
-     @project_1 = Project.create!(title: 'Shelf Lake Trail Restoration', date: "2019-06-30", organizer: @admin, description: "You'll work to improve a half-mile section of the popular Shelf Lake Trail. This project is relatively small with 20-25 volunteers and tasks may be technical in nature as you install water bars, check steps, and other drainage structures as well as build new rock step stream crossings. If you are new to trail work, don't worry! No previous experience is required; just be prepared to work hard at high altitude among classic Colorado views.", active: true, image: 'https://www.voc.org/sites/default/files/styles/760x420/public/op_images/ShelfLake_8.jpg?itok=_ZH6V4li')
+     @project_1 = Project.create!(title: 'Shelf Lake Trail Restoration', date: future_date, organizer: @admin, description: "You'll work to improve a half-mile section of the popular Shelf Lake Trail. This project is relatively small with 20-25 volunteers and tasks may be technical in nature as you install water bars, check steps, and other drainage structures as well as build new rock step stream crossings. If you are new to trail work, don't worry! No previous experience is required; just be prepared to work hard at high altitude among classic Colorado views.", active: true, image: 'https://www.voc.org/sites/default/files/styles/760x420/public/op_images/ShelfLake_8.jpg?itok=_ZH6V4li')
      @address_1 = Address.create!(owner: @project_1, line_1: "Shelf Lake Trailhead", line_2: "Co Rd 1038", city: "Grant", state: "CO", zip: "80448")
 
      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
@@ -23,7 +25,7 @@ describe 'As an admin' do
      expect(current_path).to eq(edit_admin_project_path(@project_1))
      expect(page.find_field('Title').value).to eq(@project_1.title)
      expect(page.find_field('Description').value).to eq(@project_1.description)
-     expect(page.find_field('Date').value).to eq('2019-06-30')
+     expect(page.find_field('Date').value).to eq(future_date)
 
      expect(page.find_field('Line 1').value).to eq(@project_1.location.line_1)
      expect(page.find_field('Line 2').value).to eq(@project_1.location.line_2)
@@ -46,14 +48,15 @@ describe 'As an admin' do
   end
 
   it 'shows an error message if project fields not filled out correctly' do
-    fill_in 'Date', with: '2018-01-01'
+    new_date = (Date.today >> 2).strftime('%Y-%m-%d')
+    fill_in 'Date', with: new_date
 
     click_button("Update Project")
 
     expect(current_path).to eq(admin_project_path(@project_1))
     expect(page).to have_content("Date cannot be in the past")
     expect(page.find_field('Title').value).to eq(@project_1.title)
-    expect(page.find_field('Date').value).to eq('2018-01-01')
+    expect(page.find_field('Date').value).to eq(new_date)
   end
 
   it 'shows an error message if project address fields not filled out correctly' do
@@ -64,7 +67,7 @@ describe 'As an admin' do
     expect(current_path).to eq(admin_project_path(@project_1))
     expect(page).to have_content("Location line 1 can't be blank")
     expect(page.find_field('Title').value).to eq(@project_1.title)
-    expect(page.find_field('Date').value).to eq('2019-06-30')
+    expect(page.find_field('Date').value).to eq(future_date)
   end
 
 end

--- a/spec/features/admins/projects/edit_spec.rb
+++ b/spec/features/admins/projects/edit_spec.rb
@@ -3,7 +3,7 @@ require 'date'
 
 describe 'As an admin' do
   before :each do
-    future_date = (Date.today >> 1).strftime('%Y-%m-%d')
+    @future_date = (Date.today >> 1).strftime('%Y-%m-%d')
     @admin = User.new(full_name: "Vincent",
                      email: "vincent@example.com",
                      about: "TBD",
@@ -12,7 +12,7 @@ describe 'As an admin' do
                      google_id: nil,
                      role: 2,
                      active: true)
-     @project_1 = Project.create!(title: 'Shelf Lake Trail Restoration', date: future_date, organizer: @admin, description: "You'll work to improve a half-mile section of the popular Shelf Lake Trail. This project is relatively small with 20-25 volunteers and tasks may be technical in nature as you install water bars, check steps, and other drainage structures as well as build new rock step stream crossings. If you are new to trail work, don't worry! No previous experience is required; just be prepared to work hard at high altitude among classic Colorado views.", active: true, image: 'https://www.voc.org/sites/default/files/styles/760x420/public/op_images/ShelfLake_8.jpg?itok=_ZH6V4li')
+     @project_1 = Project.create!(title: 'Shelf Lake Trail Restoration', date: @future_date, organizer: @admin, description: "You'll work to improve a half-mile section of the popular Shelf Lake Trail. This project is relatively small with 20-25 volunteers and tasks may be technical in nature as you install water bars, check steps, and other drainage structures as well as build new rock step stream crossings. If you are new to trail work, don't worry! No previous experience is required; just be prepared to work hard at high altitude among classic Colorado views.", active: true, image: 'https://www.voc.org/sites/default/files/styles/760x420/public/op_images/ShelfLake_8.jpg?itok=_ZH6V4li')
      @address_1 = Address.create!(owner: @project_1, line_1: "Shelf Lake Trailhead", line_2: "Co Rd 1038", city: "Grant", state: "CO", zip: "80448")
 
      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
@@ -25,7 +25,7 @@ describe 'As an admin' do
      expect(current_path).to eq(edit_admin_project_path(@project_1))
      expect(page.find_field('Title').value).to eq(@project_1.title)
      expect(page.find_field('Description').value).to eq(@project_1.description)
-     expect(page.find_field('Date').value).to eq(future_date)
+     expect(page.find_field('Date').value).to eq(@future_date)
 
      expect(page.find_field('Line 1').value).to eq(@project_1.location.line_1)
      expect(page.find_field('Line 2').value).to eq(@project_1.location.line_2)
@@ -67,7 +67,7 @@ describe 'As an admin' do
     expect(current_path).to eq(admin_project_path(@project_1))
     expect(page).to have_content("Location line 1 can't be blank")
     expect(page.find_field('Title').value).to eq(@project_1.title)
-    expect(page.find_field('Date').value).to eq(future_date)
+    expect(page.find_field('Date').value).to eq(@future_date)
   end
 
 end

--- a/spec/features/admins/projects/edit_spec.rb
+++ b/spec/features/admins/projects/edit_spec.rb
@@ -48,7 +48,7 @@ describe 'As an admin' do
   end
 
   it 'shows an error message if project fields not filled out correctly' do
-    new_date = (Date.today >> 2).strftime('%Y-%m-%d')
+    new_date = (Date.today << 1).strftime('%Y-%m-%d')
     fill_in 'Date', with: new_date
 
     click_button("Update Project")

--- a/spec/services/mapbox_service_spec.rb
+++ b/spec/services/mapbox_service_spec.rb
@@ -8,6 +8,11 @@ describe MapboxService do
     result = mapbox_service.get_coords(address)
 
     expect(result).to be_a(Hash)
-    expect(result[:features].first[:center]).to eq([-104.99625, 39.75109])
+
+    coords = result[:features].first[:center]
+    expect(coords[0]).to be > -105
+    expect(coords[0]).to be < -104.9
+    expect(coords[1]).to be > 39.7
+    expect(coords[1]).to be < 39.8
   end
 end


### PR DESCRIPTION
- Some tests were failing due to hard-coded dates in the tests. Replaced those hard-coded dates with `Date.today` +- 1mo. 
- Fixed a test with Mapbox where their data changed, and our expectation was too specific. Changed the test to expect a result within a reasonably tight range which should allow for the exact returned location to move around a little as Mapbox data is updated.
- Also includes pre-demo fixes including optimized routing and better seed data.